### PR TITLE
Fix high score position and bonus for hitting enemies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   DisplayConfig class; added support for scaling the window frame and scoreboard in
   full-map mode.
 
+* Bugfix: add 200 points every time an enemy (ghost, mummy, vampire or skeleton) is hit by
+  a bullet.
+
 # 0.3.1
 
 * Use custom package name in Android app, instead of the default app.libsdl.org. In

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Bugfix: add 200 points every time an enemy (ghost, mummy, vampire or skeleton) is hit by
   a bullet.
 
+* Bugfix: intentionally mis-align the current score and the high score, as the original
+  game did it. The high score numer is one pixel to the left of the current score.
+
 # 0.3.1
 
 * Use custom package name in Android app, instead of the default app.libsdl.org. In

--- a/cpp/GameRunner.cpp
+++ b/cpp/GameRunner.cpp
@@ -101,9 +101,11 @@ void GameRunner::checkBulletCollisions()
                 continue;
             else if (effect == Sprite::BulletEffect::HIT)
             {
+                addScore(200);
                 bullet_list.pop_back();
                 return;
             }
+            addScore(200);
             auto &smoke_list = getSpriteList(SpriteClass::SMOKE);
             sprite_pos.yadd(1);
             smoke_list.emplace_back(std::make_unique<Smoke>(sprite_pos));

--- a/cpp/fredcore/Window.cpp
+++ b/cpp/fredcore/Window.cpp
@@ -163,7 +163,6 @@ void Window::renderFrame(GameBase const &game, DisplayConfig const &display_cfg,
     }
 
     auto [sb_w, sb_h] = display_cfg.setScoreboardViewport();
-    //SDL_Log("frame_w=%d frame_h=%d sb_w=%d wb_h=%d", frame_w, frame_h, sb_w, sb_h);
     for (int y = 0; y < sb_h; y += MapPos::PIXELS_PER_CHAR)
     {
         SDL_Rect dst_rect = {0, y, MapPos::PIXELS_PER_CHAR, MapPos::PIXELS_PER_CHAR};
@@ -199,7 +198,7 @@ void Window::renderFrame(GameBase const &game, DisplayConfig const &display_cfg,
                      dst_scoreboard.x + 3, dst_scoreboard.y + 17 * 8 + 2,
                      206, 206, 206);
     tmgr.renderScore(display_cfg.getRenderer(), game.getHighScore(),
-                     dst_scoreboard.x + 3, dst_scoreboard.y + 20 * 8 + 2,
+                     dst_scoreboard.x + 2, dst_scoreboard.y + 20 * 8 + 2,
                      206, 206, 206);
 
     SDL_Texture *power_texture = tmgr.get(TextureID::POWER);


### PR DESCRIPTION
Fix a couple of minor differences with the original game:

* Player gets 200 points every time an enemy is hit.
* The high score number has been moved one pixel to the left.