### PR TITLE
Remove low latency audio requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.1
+
+* Removed unnecessary "low latency audio" feature from Android manifest. Some users are
+  getting an "incompatible device" error when they try to download the app from Google
+  Play, and this may be the fix for it.
+
 # 0.4.0
 
 * Refactored "full-map" mode: moved the initialization of the SDL window to the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project("retro-fred" VERSION 0.4.0)
+project("retro-fred" VERSION 0.4.1)
 
 file(CONFIGURE OUTPUT version CONTENT "${CMAKE_PROJECT_VERSION}\n")
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 6
-        versionName "0.4.0"
+        versionCode 7
+        versionName "0.4.1"
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_APP_PLATFORM=android-19", "-DANDROID_STL=c++_static"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
      com.gamemaker.game
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="6"
-    android:versionName="0.4.0"
+    android:versionCode="7"
+    android:versionName="0.4.1"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->
@@ -14,8 +14,6 @@
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
-
-    <uses-feature android:name="android.hardware.audio.low_latency" android:required="true" />
 
     <!-- Game controller support -->
     <uses-feature

--- a/android/versions
+++ b/android/versions
@@ -1,5 +1,6 @@
 # Mapping between version names and Android version codes
 # version   code    description
+0.4.1       7       Remove unnecessary low-latency audio feature from manifest
 0.4.0       6       Scale up window frame and HUD on full-map mode
 0.3.1       5       Fix font seeping
 0.3.1       4       First closed test release


### PR DESCRIPTION
Remove unnecessary feature requirement in Android
manifest. We expect that this will fix the
"incompatible device" issues that some users are
experiencing when trying to download the app from
Google Play.