### PR TITLE
Fix out-of-bounds object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.2
+
+* Fix out-of-bounds object type bug: it was causing object pickup sounds to be played at 
+  unexpected times.
+
 # 1.0.1
 
 * First release in the Apple App Store, as version 1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project("retro-fred" VERSION 1.0.1)
+project("retro-fred" VERSION 1.0.2)
 
 file(CONFIGURE OUTPUT version CONTENT "${CMAKE_PROJECT_VERSION}\n")
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 12
-        versionName "1.0.1"
+        versionCode 13
+        versionName "1.0.2"
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_APP_PLATFORM=android-19",

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
      com.gamemaker.game
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="12"
-    android:versionName="1.0.1"
+    android:versionCode="13"
+    android:versionName="1.0.2"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->

--- a/android/versions
+++ b/android/versions
@@ -1,5 +1,6 @@
 # Mapping between version names and Android version codes
 # version   code    description
+1.0.2       13      Fix out-of-bounds object type bug.
 1.0.1       12      Add support for iOS
 1.0.0       11      First official release
 0.4.2       10      Refactor configuration menus

--- a/cpp/Object.cpp
+++ b/cpp/Object.cpp
@@ -6,7 +6,7 @@ void Object::initialize(std::minstd_rand &random_engine, GameBase &game)
     auto &sprite_list = game.getSpriteList(SpriteClass::OBJECT);
     std::uniform_int_distribution<> distrib_x(1, game.getGameMap().getWidth() - 2);
     std::uniform_int_distribution<> distrib_y(1, game.getGameMap().getHeight() - 4);
-    std::uniform_int_distribution<> distrib_t(0, static_cast<int>(Object::Type::COUNT));
+    std::uniform_int_distribution<> distrib_t(0, static_cast<int>(Object::Type::COUNT) - 1);
     // TODO: the number of objects depends on the game level. Also not all objects are
     // allowed in all levels.
     for (int counter = game.getSpriteCount().objects; counter > 0;)


### PR DESCRIPTION
We use a uniform distribution to randomly pick the object type. The range in this distribution exceded the valid values for the object type. Because of this some objects were being generated with an object type of Object::Type::COUNT. This was causing out-of-bounds access to some arrays, giving invalid values to the bounding box of the object. The effect was that some objects would seem to be large enough to cover the whole map, which was causing Fred to immediately pick them at the start of the game. This manifested as the object pick-up sound being played at the beginning of the game.