### PR TITLE
Prevent a crash if playChannel() fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+* Avoid crashing if playChannel() fails.
+
 # 1.0.2
 
 * Use static build for Linux and MacOS builds.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
-project("retro-fred" VERSION 1.0.2)
+project("retro-fred" VERSION 1.0.3)
 
 file(CONFIGURE OUTPUT version CONTENT "${CMAKE_PROJECT_VERSION}\n")
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 14
-        versionName "1.0.2"
+        versionCode 15
+        versionName "1.0.3"
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_APP_PLATFORM=android-19",

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
      com.gamemaker.game
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="14"
-    android:versionName="1.0.2"
+    android:versionCode="15"
+    android:versionName="1.0.3"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->

--- a/android/versions
+++ b/android/versions
@@ -1,5 +1,6 @@
 # Mapping between version names and Android version codes
 # version   code    description
+1.0.3       15      Prevent crashing if playChannel() fails
 1.0.2       14      Adjust controller position; use hi-res logo
 1.0.2       13      Fix object type bug; link sdl statically
 1.0.1       12      Add support for iOS

--- a/cpp/fredcore/sdl.hpp
+++ b/cpp/fredcore/sdl.hpp
@@ -24,7 +24,7 @@ namespace sdl
     class App
     {
     public:
-        App(Uint32 flags = SDL_INIT_EVERYTHING)
+        App(Uint32 flags = SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_EVENTS)
         {
             if (SDL_Init(flags) < 0)
                 throw Error();
@@ -158,8 +158,10 @@ namespace sdl
         int playChannel(Mix_Chunk *chunk, int channel = -1, int loops = 0)
         {
             auto out_channel = Mix_PlayChannel(channel, chunk, loops);
-            if (out_channel < 0)
-                throw Error();
+            if (out_channel < 0) {
+                SDL_Log("sdl::playChannel: failed to play sound: %s", SDL_GetError());
+                SDL_ClearError();
+            }
             return out_channel;
         }
         Uint32 getDuration(Mix_Chunk *chunk) const noexcept

--- a/ios/Retro-Fred.xcodeproj/project.pbxproj
+++ b/ios/Retro-Fred.xcodeproj/project.pbxproj
@@ -682,7 +682,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8P2R7JZF87;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -714,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eightbitfred.RetroFred;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -728,7 +728,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8P2R7JZF87;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -756,7 +756,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eightbitfred.RetroFred;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
playChannel() has been known to fail in some cases in Android tests. When this happens it used to throw an exception, which caused a crash. Prevent the crash by just logging the error and cotninue silently.