### PR TITLE
Skip accelerometer joysticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+* Ignore accelerometer joysticks
+
 # 1.1.0
 
 * Add basic support for joysticks and game pads. We map SDL events for joystick axis, hats

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
-project("retro-fred" VERSION 1.1.0)
+project("retro-fred" VERSION 1.1.1)
 
 file(CONFIGURE OUTPUT version CONTENT "${CMAKE_PROJECT_VERSION}\n")
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 17
-        versionName "1.1.0"
+        versionCode 18
+        versionName "1.1.1"
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_APP_PLATFORM=android-19",

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
      com.gamemaker.game
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="17"
-    android:versionName="1.1.0"
+    android:versionCode="18"
+    android:versionName="1.1.1"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->

--- a/android/versions
+++ b/android/versions
@@ -1,5 +1,6 @@
 # Mapping between version names and Android version codes
 # version   code    description
+1.1.1       18      Ignore accelerometer joysticks
 1.1.0       17      Add support for joysticks and gamepads
 1.0.4       16      Use newer SDL2 release to avoid issues with Android 15
 1.0.3       15      Prevent crashing if playChannel() fails

--- a/cpp/fredcore/GameEvent.cpp
+++ b/cpp/fredcore/GameEvent.cpp
@@ -78,8 +78,15 @@ EventManager::EventManager(std::uint32_t ticks_per_frame)
     , next_frame(SDL_GetTicks() + ticks_per_frame)
 {
     // If there are any joysticks open the first one
-    if (SDL_NumJoysticks() > 0)
-        joystick = sdl::JoystickPtr(SDL_JoystickOpen(0));
+
+    for (int i = 0; i < SDL_NumJoysticks(); ++i)
+    {
+        auto candidate = sdl::JoystickPtr(SDL_JoystickOpen(i));
+        if (SDL_JoystickNumAxes(candidate) >= 2 && SDL_JoystickNumButtons(candidate) >= 2) {
+            joystick = std::move(candidate);
+            break;
+        }
+    }
 }
 
 void EventManager::getJoystickHatEvent(EventMask &event_mask, Uint8 hat_position)

--- a/ios/Retro-Fred.xcodeproj/project.pbxproj
+++ b/ios/Retro-Fred.xcodeproj/project.pbxproj
@@ -682,7 +682,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 8P2R7JZF87;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -714,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eightbitfred.RetroFred;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -728,7 +728,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 8P2R7JZF87;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -756,7 +756,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eightbitfred.RetroFred;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
Quick fix to ignore joysticks that do not have at least two axis and two buttons. This is an effort to avoid accelerometer joysticks, which were causing erratic behavior when no joystick devices were connected.