### PR TITLE
Improve joystick/game controller support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.2
+
+* Add SDL hint to avoid detecting accelerometer devices are joysticks.
+
+* Use the controller API if a joystick is detected as a controller.
+
 # 1.1.1
 
 * Ignore accelerometer joysticks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
-project("retro-fred" VERSION 1.1.1)
+project("retro-fred" VERSION 1.1.2)
 
 file(CONFIGURE OUTPUT version CONTENT "${CMAKE_PROJECT_VERSION}\n")
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 18
-        versionName "1.1.1"
+        versionCode 19
+        versionName "1.1.2"
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_APP_PLATFORM=android-19",

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
      com.gamemaker.game
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="18"
-    android:versionName="1.1.1"
+    android:versionCode="19"
+    android:versionName="1.1.2"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->

--- a/android/versions
+++ b/android/versions
@@ -1,5 +1,6 @@
 # Mapping between version names and Android version codes
 # version   code    description
+1.1.2       19      Use controller API if possible
 1.1.1       18      Ignore accelerometer joysticks
 1.1.0       17      Add support for joysticks and gamepads
 1.0.4       16      Use newer SDL2 release to avoid issues with Android 15

--- a/cpp/Application.cpp
+++ b/cpp/Application.cpp
@@ -152,7 +152,7 @@ class StateMainMenu : public BaseState
         tmgr.renderText(renderer, "CHARACTER DESIGN: GAELIC", 0, 144, 206, 206, 206);
         tmgr.renderText(renderer, "PET: SENATOR & DRULY'S DUCK", 0, 152, 206, 206, 206);
         tmgr.renderText(renderer, "MISTAKES: MARTA & PALOMA", 0, 160, 206, 206, 206);
-        tmgr.renderText(renderer, "RETRO-FRED " RETRO_FRED_VERSION_STRING " \x7f 2024",
+        tmgr.renderText(renderer, "RETRO-FRED " RETRO_FRED_VERSION_STRING " \x7f 2024-2025",
                         0, 168, 206, 206, 0);
         tmgr.renderText(renderer, "    MIGUEL CATALINA", 0, 176, 206, 206, 0);
         tmgr.renderText(renderer, "    ALFREDO CATALINA", 0, 184, 206, 206, 0);

--- a/cpp/fredcore/GameEvent.hpp
+++ b/cpp/fredcore/GameEvent.hpp
@@ -3,6 +3,7 @@
 #include "sdl.hpp"
 #include <optional>
 #include <map>
+#include <cstdint>
 
 class Controller;
 
@@ -55,6 +56,7 @@ class EventManager {
     Uint32 next_frame;
     std::optional<Uint32> timer_expiration;
     std::optional<sdl::JoystickPtr> joystick;
+    std::optional<sdl::GameControllerPtr> game_controller;
 
     static bool checkKeymod(Uint16 keymod, Uint16 mask)
     {
@@ -64,12 +66,19 @@ class EventManager {
     std::map<SDL_FingerID, GameEvent> finger_state;
     std::optional<GameEvent> getTouchEvent(Controller const &virtual_controller,
                                            SDL_TouchFingerEvent const &tfinger);
+    void tryAddJoystick(int device_index);
+    void tryRemoveJoystick(int instance_id);
     static void getJoystickHatEvent(EventMask &event_mask, Uint8 hat_position);
     static void getJoystickButtonEvent(EventMask &event_mask, Uint8 button);
+    static void getAxisEvent(EventMask &event_mask, Sint16 x, Sint16 y);
     void getJoystickAxisEvent(EventMask &event_mask);
+    void getGameControllerButtonEvent(EventMask &event_mask);
+    void getGameControllerAxisEvent(EventMask &event_mask);
 
 public:
-    explicit EventManager(std::uint32_t ticks_per_frame);
+    explicit EventManager(std::uint32_t ticks_per_frame)
+        : ticks_per_frame(ticks_per_frame)
+        , next_frame(SDL_GetTicks() + ticks_per_frame) {}
     EventMask collectEvents(std::optional<Controller> const &virtual_controller);
     void setTimer(std::uint32_t ticks)
     {

--- a/cpp/fredcore/sdl.hpp
+++ b/cpp/fredcore/sdl.hpp
@@ -25,7 +25,7 @@ namespace sdl
     {
     public:
         App(Uint32 flags = SDL_INIT_AUDIO | SDL_INIT_VIDEO |
-            SDL_INIT_EVENTS | SDL_INIT_JOYSTICK)
+            SDL_INIT_EVENTS | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER)
         {
             if (SDL_Init(flags) < 0)
                 throw Error();
@@ -177,4 +177,5 @@ namespace sdl
     };
 
     using JoystickPtr = ObjectPtr<SDL_Joystick, SDL_JoystickClose>;
+    using GameControllerPtr = ObjectPtr<SDL_GameController, SDL_GameControllerClose>;
 } // namespace sdl

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -18,6 +18,7 @@ int main(int argc, char* argv[])
         std::uniform_int_distribution<std::uint32_t> distrib;
         random_engine.seed(distrib(random_dev));
     }
+    SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
     FredApp fred_app(cfg, random_engine);
     fred_app.mainLoop();
     return 0;

--- a/ios/Retro-Fred.xcodeproj/project.pbxproj
+++ b/ios/Retro-Fred.xcodeproj/project.pbxproj
@@ -682,7 +682,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 8P2R7JZF87;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -714,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eightbitfred.RetroFred;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -728,7 +728,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 8P2R7JZF87;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -756,7 +756,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eightbitfred.RetroFred;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
* Disable adding device accelerometers as joysticks

* Ignore devices that do not have at least 2 axis and at least two buttons

* Use the controller API for devices that get recognized as game controllers.